### PR TITLE
refacto: some improvements

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,25 +1,34 @@
 // Import Third-party Dependencies
 import { Scanner } from "@nodesecure/scanner";
 
-export function extractAllAuthorsFromLibrary(library: Scanner.Payload, opts: options): Promise<authorResponse[]>
+export function extractAllAuthorsFromLibrary(library: Scanner.Payload, opts: options): Promise<response>
 
 export interface options {
-  flags: flagAuthor[],
+  flags: flaggedAuthors[],
   domainInformations: boolean,
+}
+
+export interface response {
+  authors: authorResponse[],
+  flaggedAuthors: flaggedAuthors[],
 }
 
 export interface authorResponse {
   name?: string;
   email?: string;
   url?: string;
-  flagged: boolean,
-  packages: unknown[],
+  packages: {
+    homepage: string,
+    spec: string,
+    version: string,
+    at?: string,
+  }[],
   domain?: {
     expirationDate?: string,
     mxRecords?: unknown[],
   }
 }
-export interface flagAuthor {
+export interface flaggedAuthors {
   name: string,
   email: string,
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,19 +1,19 @@
 // Import Third-party Dependencies
 import { Scanner } from "@nodesecure/scanner";
 
-export function extractAllAuthorsFromLibrary(library: Scanner.Payload, opts: options): Promise<response>
+export function extractAllAuthors(library: Scanner.Payload, opts: options): Promise<extractionResult>
 
 export interface options {
-  flags: flaggedAuthors[],
+  flags: extractedAuthor[],
   domainInformations: boolean,
 }
 
-export interface response {
-  authors: authorResponse[],
-  flaggedAuthors: flaggedAuthors[],
+export interface extractionResult {
+  authors: author[],
+  flaggedAuthors: extractedAuthor[],
 }
 
-export interface authorResponse {
+export interface author {
   name?: string;
   email?: string;
   url?: string;
@@ -28,7 +28,7 @@ export interface authorResponse {
     mxRecords?: unknown[],
   }
 }
-export interface flaggedAuthors {
+export interface extractedAuthor {
   name: string,
   email: string,
 }

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ function splitAuthorNameEmail(author) {
   };
 }
 
-export async function extractAllAuthorsFromLibrary(library, opts = { flags: [], domainInformations: false }) {
+export async function extractAllAuthors(library, opts = { flags: [], domainInformations: false }) {
   if (!("dependencies" in library)) {
     return [];
   }

--- a/test/index.js
+++ b/test/index.js
@@ -17,38 +17,38 @@ const nsecureTestFile = JSON.parse(
 test("All authors from library without flags involved", async(tape) => {
   const packageTest = nsecureTestFile;
 
-  const authors = await extractAllAuthorsFromLibrary(packageTest, { flags: [], domainInformations: true });
+  const res = await extractAllAuthorsFromLibrary(packageTest, { flags: [], domainInformations: true });
 
-  tape.isNot(authors.length, 0, "There should be authors in the response");
+  tape.isNot(res.authors.length, 0, "There should be authors in the response");
   tape.end();
 });
 
 test("test authors from library with flag", async(tape) => {
   const packageTest = nsecureTestFile;
   const flaggedAuthors = [
-    { name: "Blakeembrey", email: "hello@blakeembrey.com" }
+    { name: "kesla", email: "david.bjorklund@gmail.com" }
   ];
-  const authors = await extractAllAuthorsFromLibrary(packageTest, {
+  const res = await extractAllAuthorsFromLibrary(packageTest, {
     flags: flaggedAuthors
   });
-  tape.deepEqual(authors.slice(4, 5), [{
-    name: "Blake Embrey",
-    email: "hello@blakeembrey.com",
-    flagged: true,
-    packages: [
+
+  tape.deepEqual(res.authorsFlagged, flaggedAuthors);
+  tape.deepEqual(res.authors.slice(1, 2),
+    [
       {
-        homepage: "https://github.com/blakeembrey/array-flatten",
-        spec: "array-flatten",
-        versions: "3.0.0",
-        isPublishers: false
-      },
-      {
-        homepage: "https://github.com/pillarjs/path-to-regexp#readme",
-        spec: "path-to-regexp",
-        versions: "6.2.1",
-        isPublishers: true
+        name: "kesla",
+        email: "david.bjorklund@gmail.com",
+        packages:
+          [
+            {
+              homepage: "https://github.com/jshttp/etag#readme",
+              spec: "etag",
+              versions: "1.8.1",
+              at: "2014-05-18T11:14:58.281Z"
+            }
+          ]
       }
     ]
-  }]);
+  );
   tape.end();
 });

--- a/test/index.js
+++ b/test/index.js
@@ -6,7 +6,7 @@ import { readFile } from "fs/promises";
 import test from "tape";
 
 // Import Internal Dependencies
-import { extractAllAuthorsFromLibrary } from "../src/index.js";
+import { extractAllAuthors } from "../src/index.js";
 
 const nsecureTestFile = JSON.parse(
   await readFile(
@@ -17,7 +17,7 @@ const nsecureTestFile = JSON.parse(
 test("All authors from library without flags involved", async(tape) => {
   const packageTest = nsecureTestFile;
 
-  const res = await extractAllAuthorsFromLibrary(packageTest, { flags: [], domainInformations: true });
+  const res = await extractAllAuthors(packageTest, { flags: [], domainInformations: true });
 
   tape.isNot(res.authors.length, 0, "There should be authors in the response");
   tape.end();
@@ -28,7 +28,7 @@ test("test authors from library with flag", async(tape) => {
   const flaggedAuthors = [
     { name: "kesla", email: "david.bjorklund@gmail.com" }
   ];
-  const res = await extractAllAuthorsFromLibrary(packageTest, {
+  const res = await extractAllAuthors(packageTest, {
     flags: flaggedAuthors
   });
 


### PR DESCRIPTION
Flagged authors will now be at the root of the response
`isPublishers` is removed, when an author has an `at` property it means he's also a publisher